### PR TITLE
Patch docker ports

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -24,15 +24,15 @@ services:
     image: postgres
     restart: always
     # Set volume so database not lost after shutting down container
-    volumes:
-      - ./postgres-data:/var/lib/postgresql/data
+    # volumes:
+    #   - ./postgres-data:/var/lib/postgresql/data
     # Setup username, password, and database name
     environment:
       - POSTGRES_USER=gorm
       - POSTGRES_PASSWORD=gorm
       - POSTGRES_DB=gorm
     ports:
-      - 5432:5432
+      - 5555:5432
 
   # Container to view db
   adminer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,15 +24,16 @@ services:
     image: postgres
     restart: always
     # Set volume so database not lost after shutting down container
-    volumes:
-      - ./postgres-data:/var/lib/postgresql/data
+    # volumes:
+    #   - ./postgres-data:/var/lib/postgresql/data
     # Setup username, password, and database name
     environment:
       - POSTGRES_USER=gorm
       - POSTGRES_PASSWORD=gorm
       - POSTGRES_DB=gorm
     ports:
-      - 5432:5432
+      # Map to localhost:5555 so no conflicts with local instance of postgres
+      - 5555:5432
 
   # Container to view db
   adminer:


### PR DESCRIPTION
- Updated docker files to remove issues with using volumes.
- Mapped docker Postgres ports from 5432 to 5555 so you can run this docker service without stopping a local version of Postgres.