### PR TITLE
updated docker-compose to run with honeyclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,17 @@
 ## Running web app with docker-compose
 
 1. Make sure you have docker installed locally.
-2. Copy the docker-compose file into the root project directory, where `api`,
-   `frontend`, and `honeyclient` are all subdirectories
-3. Run `docker-compose up`. (this will take a while to build the first time,
-   runs using locally built images from subdirectories)
+2. Run `docker-compose up`. This will use images hosted on Docker Hub (ex: our [API image](https://hub.docker.com/repository/docker/csci4950tgt/api)) that are
+   automatically built from each service's github master branch
 
 That should be it.
 
 **Optional**
-To run with images hosted on Docker Hub (ex: our [API image](https://hub.docker.com/repository/docker/csci4950tgt/api)), use the following command:
 
-`docker-compose -f docker-compose.production.yml up`
+To run with locally built images, do the following:
+
+1. Copy the docker-compose file into the root project directory, where `api`,
+   `frontend`, and `honeyclient` are all subdirectories
+
+2. Run `docker-compose -f docker-compose.development.yml up --build` (this will take a while to build the first time,
+   runs using locally built images from subdirectories)

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,12 +1,27 @@
+### Uses locally built images for each service
+
 version: "3"
 services:
   api:
-    image: csci4950tgt/api
+    build: ./api
     restart: always
-    # Need to wait for postgres to start
-    command: ["./wait-for-it.sh", "db:5432", "--", "./api"]
     ports:
       - 8080:8080
+    # Need to wait for postgres to start
+    command: ["./wait-for-it.sh", "db:5432", "--", "./api"]
+    depends_on:
+      - db
+    links:
+      - db
+    environment:
+      - PG_HOST=db
+
+  honeyclient:
+    build: ./honeyclient
+    restart: always
+    # Need to wait for postgres to start
+    ports:
+      - 8000:8000
     depends_on:
       - db
     links:
@@ -15,7 +30,7 @@ services:
       - PG_HOST=db
 
   frontend:
-    image: csci4950tgt/frontend
+    build: ./frontend
     restart: always
     ports:
       - 3000:80
@@ -32,9 +47,10 @@ services:
       - POSTGRES_PASSWORD=gorm
       - POSTGRES_DB=gorm
     ports:
+      # Map to localhost:5555 so no conflicts with local instance of postgres
       - 5555:5432
 
-  # Container to view db
+  # Container to interact with db
   adminer:
     image: adminer
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,27 @@
+### Uses hosted docker images for all containers. Nothing is locally built
+
 version: "3"
 services:
   api:
-    build: ./api
+    image: csci4950tgt/api
     restart: always
-    # Need to wait for postgres to start
-    command: ["./wait-for-it.sh", "db:5432", "--", "./api"]
     ports:
       - 8080:8080
+    # Need to wait for postgres to start
+    command: ["./wait-for-it.sh", "db:5432", "--", "./api"]
+    depends_on:
+      - db
+    links:
+      - db
+    environment:
+      - PG_HOST=db
+
+  honeyclient:
+    build: csci4950tgt/honeyclient
+    restart: always
+    ports:
+      - 8000:8000
+    # Need to wait for postgres to start
     depends_on:
       - db
     links:
@@ -15,7 +30,7 @@ services:
       - PG_HOST=db
 
   frontend:
-    build: ./frontend
+    image: csci4950tgt/frontend
     restart: always
     ports:
       - 3000:80
@@ -32,10 +47,9 @@ services:
       - POSTGRES_PASSWORD=gorm
       - POSTGRES_DB=gorm
     ports:
-      # Map to localhost:5555 so no conflicts with local instance of postgres
       - 5555:5432
 
-  # Container to view db
+  # Container to interact with db
   adminer:
     image: adminer
     restart: always


### PR DESCRIPTION
Now anyone who has docker installed can simply clone this repo and run `docker-compose up` to run the entire app (with the frontend, honeyclient, api, and db working together)

The default docker-compose.yml file will run using images on Docker Hub, gave optional instructions in the README to run from locally built images