### PR TITLE
Wrote run service and cleanup service scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@ To run with locally built images, do the following:
 
 2. Run `docker-compose -f docker-compose.development.yml up --build` (this will take a while to build the first time,
    runs using locally built images from subdirectories)
+
+## Running web app locally with bash script
+
+Currently only have a bash script that works on macs. Not sure if this works on linux.
+
+1. Make sure you have the `mac_run_service.sh` and `mac_cleanup_service.sh` scripts in a parent directory, in the same level as your `api`, `honeyclient`, and `frontend` repos.
+2. Run like so:
+
+   ```sh
+   sh mac_run_service.sh
+   ```
+
+3. The cleanup script isn't auto executing when you CTRL:C out of that command, so also run the cleanup script to kill any remaining processes from this service.
+
+   ```sh
+   sh mac_cleanup_service.sh
+   ```

--- a/mac_cleanup_service.sh
+++ b/mac_cleanup_service.sh
@@ -1,0 +1,21 @@
+echo Service shutting down...
+
+### kill processes if still running
+
+# Honeyclient
+pid=$(lsof -ti tcp:8000)
+if [[ $pid ]]; then
+  kill -9 $pid
+fi
+
+# Api
+pid=$(lsof -ti tcp:8080)
+if [[ $pid ]]; then
+  kill -9 $pid
+fi
+
+# Frontend
+pid=$(lsof -ti tcp:3000)
+if [[ $pid ]]; then
+  kill -9 $pid
+fi

--- a/mac_run_service.sh
+++ b/mac_run_service.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+cd ./api && go build && ./api   &    # run api
+cd honeyclient && npm run start &    # run honeyclient
+cd frontend && npm run start    &    # run frontend
+
+wait
+
+####### CLEANUP CODE ########
+
+sh mac_run_service.sh


### PR DESCRIPTION
Fixes issue #6 

### Notes
- Works on mac but not sure about linux
- How to run the commands (I put this in the README also)

  1. Make sure you have these scripts in a parent directory, in the same level as your api, honeyclient, and frontend repos
  2. Run like so: `sh mac_run_service.sh`
  3. Cleanup script isn't auto executing when you CTRL:C out of that command, so also run `sh mac_cleanup_service.sh` to kill any remaining processes from this service

